### PR TITLE
fix: unable to skip the unavailable tracker

### DIFF
--- a/src/main/java/org/csource/common/MyException.java
+++ b/src/main/java/org/csource/common/MyException.java
@@ -16,6 +16,7 @@ package org.csource.common;
  */
 public class MyException extends Exception {
   public MyException(String s, Exception e) {
+    super(s,e);
   }
 
   public MyException(String message) {

--- a/src/main/java/org/csource/fastdfs/TrackerGroup.java
+++ b/src/main/java/org/csource/fastdfs/TrackerGroup.java
@@ -87,7 +87,7 @@ public class TrackerGroup {
       }
     }
 
-    return null;
+    throw new IOException("can not found available server, please check: " + tracker_servers);
   }
 
   public Object clone() {

--- a/src/main/java/org/csource/fastdfs/TrackerServer.java
+++ b/src/main/java/org/csource/fastdfs/TrackerServer.java
@@ -8,7 +8,6 @@
 
 package org.csource.fastdfs;
 
-import org.csource.common.MyException;
 import org.csource.fastdfs.pool.Connection;
 import org.csource.fastdfs.pool.ConnectionPool;
 import org.csource.fastdfs.pool.ConnectionFactory;
@@ -26,11 +25,12 @@ public class TrackerServer {
     protected InetSocketAddress inetSockAddr;
 
 
-    public TrackerServer(InetSocketAddress inetSockAddr) throws IOException {
+    public TrackerServer(InetSocketAddress inetSockAddr) throws IOException{
         this.inetSockAddr = inetSockAddr;
+        checkServerEnabled();
     }
 
-    public Connection getConnection() throws MyException, IOException {
+    public Connection getConnection() throws IOException {
         Connection connection;
         if (ClientGlobal.g_connection_pool_enabled) {
             connection = ConnectionPool.getConnection(this.inetSockAddr);
@@ -48,4 +48,16 @@ public class TrackerServer {
         return this.inetSockAddr;
     }
 
+    /**
+     * check server enabled
+     * @throws IOException
+     */
+    public void checkServerEnabled() throws IOException {
+        Connection connection = getConnection();
+        try {
+            connection.release();
+        }catch (Exception e){
+            //ignore
+        }
+    }
 }

--- a/src/main/java/org/csource/fastdfs/pool/ConnectionFactory.java
+++ b/src/main/java/org/csource/fastdfs/pool/ConnectionFactory.java
@@ -15,7 +15,7 @@ public class ConnectionFactory {
      * @return
      * @throws IOException
      */
-    public static Connection create(InetSocketAddress socketAddress) throws MyException {
+    public static Connection create(InetSocketAddress socketAddress) throws IOException {
         try {
             Socket sock = new Socket();
             sock.setReuseAddress(true);
@@ -23,7 +23,7 @@ public class ConnectionFactory {
             sock.connect(socketAddress, ClientGlobal.g_connect_timeout);
             return new Connection(sock, socketAddress);
         } catch (Exception e) {
-            throw new MyException("connect to server " + socketAddress.getAddress().getHostAddress() + ":" + socketAddress.getPort() + " fail, emsg:" + e.getMessage());
+            throw new IOException("connect to server " + socketAddress.getAddress().getHostAddress() + ":" + socketAddress.getPort() + " fail, emsg:" + e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/org/csource/fastdfs/pool/ConnectionManager.java
+++ b/src/main/java/org/csource/fastdfs/pool/ConnectionManager.java
@@ -45,7 +45,7 @@ public class ConnectionManager {
         this.inetSocketAddress = socketAddress;
     }
 
-    public Connection getConnection() throws MyException {
+    public Connection getConnection() throws IOException {
         lock.lock();
         try {
             Connection connection = null;
@@ -81,10 +81,10 @@ public class ConnectionManager {
                             //wait single success
                             continue;
                         }
-                        throw new MyException("connect to server " + inetSocketAddress.getAddress().getHostAddress() + ":" + inetSocketAddress.getPort() + " fail, wait_time > " + ClientGlobal.g_connection_pool_max_wait_time_in_ms + "ms");
+                        throw new IOException("connect to server " + inetSocketAddress.getAddress().getHostAddress() + ":" + inetSocketAddress.getPort() + " fail, wait_time > " + ClientGlobal.g_connection_pool_max_wait_time_in_ms + "ms");
                     } catch (InterruptedException e) {
                         e.printStackTrace();
-                        throw new MyException("connect to server " + inetSocketAddress.getAddress().getHostAddress() + ":" + inetSocketAddress.getPort() + " fail, emsg:" + e.getMessage());
+                        throw new IOException("connect to server " + inetSocketAddress.getAddress().getHostAddress() + ":" + inetSocketAddress.getPort() + " fail, emsg:" + e.getMessage());
                     }
                 }
                 return connection;

--- a/src/main/java/org/csource/fastdfs/pool/ConnectionPool.java
+++ b/src/main/java/org/csource/fastdfs/pool/ConnectionPool.java
@@ -13,7 +13,7 @@ public class ConnectionPool {
      */
     private final static ConcurrentHashMap<String, ConnectionManager> CP = new ConcurrentHashMap<String, ConnectionManager>();
 
-    public static Connection getConnection(InetSocketAddress socketAddress) throws MyException {
+    public static Connection getConnection(InetSocketAddress socketAddress) throws IOException {
         if (socketAddress == null) {
             return null;
         }


### PR DESCRIPTION
to solve the issue: https://github.com/happyfish100/fastdfs-client-java/issues/76#issue-622380089

current version(1.29-SNAPSHOT) bug: new TrackerServer() not check the tracker available or not,  IOException is no longer thrown.