### PR TITLE
简单增加内网IP映射支持。在某些情况下，fdfs配置在内网，但是需要通过外网映射来操作Fdfs，可通过配置来进行处理。

### DIFF
--- a/src/main/java/org/csource/common/ConfigureMapper.java
+++ b/src/main/java/org/csource/common/ConfigureMapper.java
@@ -1,0 +1,60 @@
+package org.csource.common;
+
+import java.util.Properties;
+
+/**
+ * Description: 在特殊的内外网环境下，如果fdfs配置在内网，但是想通过外网操作fdfs上传文件，可以使用本配置方法来做IP映射。
+ * 前提：外网映射的IP端口可达。
+ * 配置格式：内网ip=外网IP:外网端口
+ *
+ * @author kyq
+ * @version 1.0
+ * @Date 2020/9/4 9:41
+ */
+public class ConfigureMapper {
+    private static final String SYS_CONFIG_FILE = "fdfs_ip_mapper.properties";
+    private static Properties sysProperties = new Properties();
+
+    static {
+        try {
+            sysProperties.load(Thread.currentThread().getContextClassLoader().getResourceAsStream("fdfs_ip_mapper.properties"));
+        } catch (Exception var1) {
+            System.out.println("fdfs_ip_mapper.properties not found!");
+        }
+
+    }
+
+    public static String getProperty(String strKey) {
+        String strValue = "";
+
+        try {
+            strValue = sysProperties.getProperty(strKey);
+        } catch (Exception var3) {
+            System.out.println("Property <" + strKey + "> not found!");
+        }
+
+        return replaceNull(strValue);
+    }
+
+    public static String replaceNull(Object obj) {
+        return isEmpty(obj) ? "" : obj.toString();
+    }
+
+    public static boolean isEmpty(Object... objs) {
+        if (objs == null) {
+            return true;
+        } else {
+            Object[] var4 = objs;
+            int var3 = objs.length;
+
+            for(int var2 = 0; var2 < var3; ++var2) {
+                Object obj = var4[var2];
+                if (obj != null && !"".equals(obj)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/main/java/org/csource/fastdfs/TrackerClient.java
+++ b/src/main/java/org/csource/fastdfs/TrackerClient.java
@@ -8,6 +8,7 @@
 
 package org.csource.fastdfs;
 
+import org.csource.common.ConfigureMapper;
 import org.csource.common.MyException;
 import org.csource.fastdfs.pool.Connection;
 
@@ -247,6 +248,13 @@ public class TrackerClient {
 
                 port = (int) ProtoCommon.buff2long(pkgInfo.body, offset);
                 offset += ProtoCommon.FDFS_PROTO_PKG_LEN_SIZE;
+
+                String mapper = ConfigureMapper.getProperty(ip_addr);
+                if (!ConfigureMapper.isEmpty(new Object[]{mapper})) {
+                    String[] mappingIp = mapper.split(":");
+                    ip_addr = mappingIp[0];
+                    port = Integer.parseInt(mappingIp[1]);
+                }
 
                 results[i] = new StorageServer(ip_addr, port, store_path);
             }

--- a/src/main/resources/fdfs_ip_mapper.properties.sample
+++ b/src/main/resources/fdfs_ip_mapper.properties.sample
@@ -1,0 +1,2 @@
+# Config intranet storage ip to the mapped internet ip and port
+#10.0.11.244=113.204.217.100:22124


### PR DESCRIPTION
对内网环境部署fdfs，外网环境测试操作fdfs的场景提供IP映射配置支持。