### PR TITLE
feat: 日志依赖 log4j，具体实现由使用方决定

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,14 +15,21 @@
     <maven.test.failure.ignore>true</maven.test.failure.ignore>
     <maven.test.skip>true</maven.test.skip>
     <jdk.version>1.6</jdk.version>
+    <slf4j.version>1.7.26</slf4j.version>
   </properties>
-
 
   <dependencies>
     <dependency>
+      <artifactId>slf4j-api</artifactId>
+      <groupId>org.slf4j</groupId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.26</version>
+      <version>${slf4j.version}</version>
+      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
feat: 日志依赖 log4j，具体实现由使用方决定

* 如 Spring Boot 默认使用了 Logback，与 slf4j-log4j12 同时存在时会冲突