### PR TITLE
fix: 修复tracker_server配置为域名时，打印信息有误的问题

### DIFF
--- a/src/main/java/org/csource/fastdfs/ClientGlobal.java
+++ b/src/main/java/org/csource/fastdfs/ClientGlobal.java
@@ -337,7 +337,8 @@ public class ClientGlobal {
       InetSocketAddress[] trackerAddresses = g_tracker_group.tracker_servers;
       for (InetSocketAddress inetSocketAddress : trackerAddresses) {
         if(trackerServers.length() > 0) trackerServers += ",";
-        trackerServers += inetSocketAddress.toString().substring(1);
+        String address = inetSocketAddress.toString();
+        trackerServers += address.startsWith("/") ? address.substring(1) : address;
       }
     }
     return "{"

--- a/src/test/java/org/csource/fastdfs/ClientGlobalTests.java
+++ b/src/test/java/org/csource/fastdfs/ClientGlobalTests.java
@@ -21,6 +21,9 @@ public class ClientGlobalTests {
     ClientGlobal.initByProperties(props);
     System.out.println("ClientGlobal.configInfo(): " + ClientGlobal.configInfo());
 
+    String trackerServer = "www.baidu.com:22122";
+    ClientGlobal.initByTrackers(trackerServer);
+    System.out.println("Host >>> ClientGlobal.configInfo() : " + ClientGlobal.configInfo());
   }
 
 }


### PR DESCRIPTION
tracker_server为域名时，打印时会少一位。