### PR TITLE
feat: 发布到 maven 中央仓库

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,121 @@
-
 # FastDFS java client SDK
 
 FastDFS Java Client API may be copied only under the terms of the BSD license.
 
-## 使用ant从源码构建
+## 使用 maven 仓库
+
+已经发布到中央仓库，在 maven 项目的 `pom.xml` 中添加依赖：
+
+```xml
+
+<dependency>
+  <!-- TODO 主仓库 groupId -->
+  <groupId>io.github.rui8832</groupId>
+  <artifactId>fastdfs-client-java</artifactId>
+  <version>1.29-20211022</version>
+</dependency>
+```
+
+如果需要要使用 SNAPSHOT 版，需要在 `pom.xml` 中添加：
+
+```xml
+
+<project>
+  <dependencies>
+    <dependency>
+      <!-- TODO 主仓库 groupId -->
+      <groupId>io.github.rui8832</groupId>
+      <artifactId>fastdfs-client-java</artifactId>
+      <version>1.29-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <repositories>
+    <repository>
+      <id>ossrh-snapshot</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+    </repository>
+  </repositories>
+</project>
+```
+
+注：
+
+* 版本 `1.29-20211022` 是“正式”的 `1.29-SNAPSHOT` 版。
+* 为了通过发布到中央仓库的验证流程，我使用我了 fork 的 `groupId` 进行发布，故中央仓库的 `groupId` 与作者不一致。
+* 主仓库要发布到 maven 中央仓库需要维护者 happyfish100 注册 sonatype 帐号，生成 GPG，完成验证和发布，届时可以使用作者发布的版本。
+
+### 构建并发布到中央仓库
+
+维护者 happyfish100 注册 sonatype 帐号，生成 GPG，并在 `settings.xml` 中填入注册的帐号和 GPG 信息。
+
+执行全局替换，将 `rui8832` 替换为 `happyfish100`。
+
+然后执行下面的命令发布到中央仓库：
+
+```
+mvn -e -X -B -U -s settings.xml -P ossrh clean deploy
+```
+
+发布完成后一般 2~3 内同步到中央仓库。
+
+## 使用源码构建
+
+**使用 ant 从源码构建**
 
 ```
 ant clean package
 ```
 
-## 使用maven从源码安装
+**使用 maven 从源码安装**
 
 ```
 mvn clean install
 ```
 
-## 使用maven从jar文件安装
+**使用 maven 从 jar 文件安装**
+
 ```
 mvn install:install-file -DgroupId=org.csource -DartifactId=fastdfs-client-java -Dversion=${version} -Dpackaging=jar -Dfile=fastdfs-client-java-${version}.jar
 ```
 
-## 在您的maven项目pom.xml中添加依赖
+构建安装完成后，在您的 maven 项目的 `pom.xml` 中添加依赖：
 
 ```xml
+
 <dependency>
-    <groupId>org.csource</groupId>
-    <artifactId>fastdfs-client-java</artifactId>
-    <version>1.29-SNAPSHOT</version>
+  <groupId>org.csource</groupId>
+  <artifactId>fastdfs-client-java</artifactId>
+  <version>1.29-SNAPSHOT</version>
 </dependency>
 ```
 
-## .conf 配置文件、所在目录、加载优先顺序
+## `.conf` 配置文件、所在目录、加载优先顺序
 
-    配置文件名fdfs_client.conf(或使用其它文件名xxx_yyy.conf)
-    
-    文件所在位置可以是项目classpath(或OS文件系统目录比如/opt/):
-    /opt/fdfs_client.conf
-    C:\Users\James\config\fdfs_client.conf
-    
-    优先按OS文件系统路径读取，没有找到才查找项目classpath，尤其针对linux环境下的相对路径比如：
-    fdfs_client.conf
-    config/fdfs_client.conf
+配置文件名 `fdfs_client.conf` (或使用其它文件名 `xxx_yyy.conf`)。
+
+文件所在位置可以是项目 `classpath` (或OS文件系统目录比如 `/opt/`):
+
+```
+/opt/fdfs_client.conf
+C:\Users\James\config\fdfs_client.conf
+```
+
+优先按OS文件系统路径读取，没有找到才查找项目 `classpath`，尤其针对linux环境下的相对路径比如：
+
+```
+fdfs_client.conf
+config/fdfs_client.conf
+```
+
+配置文件示例：
 
 ```
 connect_timeout = 2
@@ -60,21 +135,30 @@ connection_pool.max_idle_time = 3600
 connection_pool.max_wait_time_in_ms = 1000
 ```
 
-    注1：tracker_server指向您自己IP地址和端口，1-n个
-    注2：除了tracker_server，其它配置项都是可选的
+注意事项：
 
+* `tracker_server` 指向您自己IP地址和端口，`1-n` 个
+* 除了 `tracker_server`，其它配置项都是可选的
 
-## .properties 配置文件、所在目录、加载优先顺序
+## `.properties` 配置文件、所在目录、加载优先顺序
 
-    配置文件名 fastdfs-client.properties(或使用其它文件名 xxx-yyy.properties)
-    
-    文件所在位置可以是项目classpath(或OS文件系统目录比如/opt/):
-    /opt/fastdfs-client.properties
-    C:\Users\James\config\fastdfs-client.properties
-    
-    优先按OS文件系统路径读取，没有找到才查找项目classpath，尤其针对linux环境下的相对路径比如：
-    fastdfs-client.properties
-    config/fastdfs-client.properties
+配置文件名 `fastdfs-client.properties`(或使用其它文件名 `xxx-yyy.properties`)。
+
+文件所在位置可以是项目 `classpath`(或OS文件系统目录比如 `/opt/`):
+
+```
+/opt/fastdfs-client.properties
+C:\Users\James\config\fastdfs-client.properties
+```
+
+优先按OS文件系统路径读取，没有找到才查找项目 `classpath`，尤其针对linux环境下的相对路径比如：
+
+```
+fastdfs-client.properties
+config/fastdfs-client.properties
+```
+
+配置文件示例：
 
 ```
 fastdfs.connect_timeout_in_seconds = 5
@@ -92,38 +176,57 @@ fastdfs.connection_pool.max_idle_time = 3600
 fastdfs.connection_pool.max_wait_time_in_ms = 1000
 ```
 
-    注1：properties 配置文件中属性名跟 conf 配置文件不尽相同，并且统一加前缀"fastdfs."，便于整合到用户项目配置文件
-    注2：fastdfs.tracker_servers 配置项不能重复属性名，多个 tracker_server 用逗号","隔开
-    注3：除了fastdfs.tracker_servers，其它配置项都是可选的
+注意事项：
 
+* `.properties` 配置文件中属性名跟 `conf` 配置文件不尽相同，并且统一加前缀"`fastdfs.`"，便于整合到用户项目配置文件
+* `fastdfs.tracker_servers` 配置项不能重复属性名，多个 `tracker_server` 用半角逗号 "`,`" 隔开
+* 除了 `fastdfs.tracker_servers` 配置项以外的其它配置项都是可选的
 
 ## 加载配置示例
 
-    加载原 conf 格式文件配置：
+加载原 `.conf` 格式文件配置：
+
+```
     ClientGlobal.init("fdfs_client.conf");
     ClientGlobal.init("config/fdfs_client.conf");
     ClientGlobal.init("/opt/fdfs_client.conf");
     ClientGlobal.init("C:\\Users\\James\\config\\fdfs_client.conf");
+```
 
-    加载 properties 格式文件配置：
+加载 `.properties` 格式文件配置：
+
+```
     ClientGlobal.initByProperties("fastdfs-client.properties");
     ClientGlobal.initByProperties("config/fastdfs-client.properties");
     ClientGlobal.initByProperties("/opt/fastdfs-client.properties");
     ClientGlobal.initByProperties("C:\\Users\\James\\config\\fastdfs-client.properties");
+```
 
-    加载 Properties 对象配置：
+加载 `Properties` 对象配置：
+
+```
     Properties props = new Properties();
     props.put(ClientGlobal.PROP_KEY_TRACKER_SERVERS, "10.0.11.101:22122,10.0.11.102:22122");
     ClientGlobal.initByProperties(props);
+```
 
-    加载 trackerServers 字符串配置：
+加载 `trackerServers` 字符串配置：
+
+```
     String trackerServers = "10.0.11.101:22122,10.0.11.102:22122";
     ClientGlobal.initByTrackers(trackerServers);
+```
 
+## 检查加载配置结果
 
-## 检查加载配置结果：
-    
+输出配置结果：
+
+```
     System.out.println("ClientGlobal.configInfo(): " + ClientGlobal.configInfo());
+```
+
+将会输出如下格式的配置信息：
+
 ```
 ClientGlobal.configInfo(): {
   g_connect_timeout(ms) = 5000

--- a/pom.xml
+++ b/pom.xml
@@ -1,21 +1,68 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <!-- TODO 主仓库 groupId -->
+  <!--
   <groupId>org.csource</groupId>
+  -->
+  <groupId>io.github.rui8832</groupId>
   <artifactId>fastdfs-client-java</artifactId>
-  <version>1.29-SNAPSHOT</version>
+  <!-- <version>1.29-SNAPSHOT</version> -->
+  <version>1.29-20211022</version>
+  <packaging>jar</packaging>
   <name>fastdfs-client-java</name>
   <description>fastdfs client for java</description>
-  <packaging>jar</packaging>
+  <url>https://github.com/happyfish100/fastdfs-client-java</url>
+
+  <organization>
+    <name>FastDFS</name>
+    <url>https://github.com/happyfish100</url>
+  </organization>
+  <licenses>
+    <license>
+      <name>BSD 3-Clause License</name>
+      <url>https://opensource.org/licenses/BSD-3-Clause</url>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>happyfish100</id>
+      <name>YuQing</name>
+      <email>happyfish100@example.com</email>
+      <url>https://github.com/happyfish100</url>
+      <timezone>+8</timezone>
+    </developer>
+  </developers>
+  <scm>
+    <!-- TODO 主仓库发布地址 -->
+    <!--
+    <connection>scm:git:git@github.com:happyfish100/fastdfs-client-java.git</connection>
+    <developerConnection>scm:git:git@github.com:happyfish100/fastdfs-client-java.git</developerConnection>
+    <url>git@github.com:happyfish100/fastdfs-client-java.git</url>
+    -->
+    <connection>scm:git:git@github.com:rui8832/fastdfs-client-java.git</connection>
+    <developerConnection>scm:git:git@github.com:rui8832/fastdfs-client-java.git</developerConnection>
+    <url>git@github.com:rui8832/fastdfs-client-java.git</url>
+  </scm>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.test.failure.ignore>true</maven.test.failure.ignore>
     <maven.test.skip>true</maven.test.skip>
+    <!-- dependencies -->
     <jdk.version>1.6</jdk.version>
-    <slf4j.version>1.7.26</slf4j.version>
+    <slf4j.version>1.7.32</slf4j.version>
+    <junit.version>4.13.2</junit.version>
+    <!-- plugin -->
+    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+    <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+    <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+    <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+    <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+    <maven-release-plugin.version>3.0.0-M1</maven-release-plugin.version>
   </properties>
 
   <dependencies>
@@ -34,7 +81,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -44,14 +91,97 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>${maven-compiler-plugin.version}</version>
         <configuration>
           <encoding>UTF-8</encoding>
           <source>${jdk.version}</source>
           <target>${jdk.version}</target>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>ossrh</id>
+      <build>
+        <plugins>
+          <!-- Source -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>${maven-source-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- Javadoc -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${maven-javadoc-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- GPG -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>${maven-gpg-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <configuration>
+                  <keyname>${gpg.keyname}</keyname>
+                  <passphraseServerId>${gpg.keyname}</passphraseServerId>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>${nexus-staging-maven-plugin.version}</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+      <distributionManagement>
+        <snapshotRepository>
+          <id>ossrh</id>
+          <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+          <id>ossrh</id>
+          <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+      </distributionManagement>
+    </profile>
+  </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,7 @@
   -->
   <groupId>io.github.rui8832</groupId>
   <artifactId>fastdfs-client-java</artifactId>
-  <!-- <version>1.29-SNAPSHOT</version> -->
-  <version>1.29-20211022</version>
+  <version>1.29-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>fastdfs-client-java</name>
   <description>fastdfs client for java</description>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,47 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                              https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>ossrh</id>
+      <!-- TODO 在 sonatype 注册的帐号 -->
+      <username>${env.SERVER_OSSRH_USERNAME}</username>
+      <password>${env.SERVER_OSSRH_PASSWORD}</password>
+    </server>
+  </servers>
+  <profiles>
+    <profile>
+      <id>central</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+    <profile>
+      <id>ossrh</id>
+      <properties>
+        <gpg.executable>gpg</gpg.executable>
+        <gpg.useagent>true</gpg.useagent>
+        <!-- <gpg.passphrase>${env.GPG_PASSWORD}</gpg.passphrase> -->
+      </properties>
+    </profile>
+  </profiles>
+</settings>

--- a/src/main/java/org/csource/fastdfs/DownloadStream.java
+++ b/src/main/java/org/csource/fastdfs/DownloadStream.java
@@ -6,7 +6,7 @@ import java.io.OutputStream;
 /**
  * Download file by stream (download callback class)
  *
- * @author zhouzezhong & Happy Fish / YuQing
+ * @author zhouzezhong, Happy Fish / YuQing
  * @version Version 1.11
  */
 public class DownloadStream implements DownloadCallback {

--- a/src/main/java/org/csource/fastdfs/UploadStream.java
+++ b/src/main/java/org/csource/fastdfs/UploadStream.java
@@ -7,7 +7,7 @@ import java.io.OutputStream;
 /**
  * Upload file by stream
  *
- * @author zhouzezhong & Happy Fish / YuQing
+ * @author zhouzezhong, Happy Fish / YuQing
  * @version Version 1.11
  */
 public class UploadStream implements UploadCallback {

--- a/src/main/java/org/csource/fastdfs/pool/ConnectionFactory.java
+++ b/src/main/java/org/csource/fastdfs/pool/ConnectionFactory.java
@@ -3,7 +3,6 @@ package org.csource.fastdfs.pool;
 import org.csource.common.MyException;
 import org.csource.fastdfs.ClientGlobal;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 
@@ -13,7 +12,7 @@ public class ConnectionFactory {
      *
      * @param socketAddress
      * @return
-     * @throws IOException
+     * @throws MyException
      */
     public static Connection create(InetSocketAddress socketAddress) throws MyException {
         try {


### PR DESCRIPTION
发布到 maven 中央仓库。

已经通过我 fork 的仓库测试发布成功，可以在项目的 `pom.xml` 中添加依赖：

```xml
<dependency>
  <groupId>io.github.rui8832</groupId>
  <artifactId>fastdfs-client-java</artifactId>
  <version>1.29-20211022</version>
</dependency>
```

为了通过发布到中央仓库的验证流程，我使用我了 fork 的 `groupId` 进行发布，故中央仓库的 `groupId` 与作者不一致。

主仓库发布到 maven 中央仓库需要维护者 @happyfish100 注册 sonatype 帐号，生成 GPG，并在 `settings.xml` 中填入注册的帐号和 GPG 信息。

执行全局替换，将 `rui8832` 替换为 `happyfish100`。

然后执行下面的命令发布到中央仓库：

```
mvn -e -X -B -U -s settings.xml -P ossrh clean deploy
```

发布完成后一般 2~3 内同步到中央仓库。

注意：帐号、密码和 GPG 等信息应当在发布完成后脱敏，不应当提交到 GitHub。